### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [develop, feature/*]


### PR DESCRIPTION
Potential fix for [https://github.com/susumutomita/bioinformatics-note/security/code-scanning/1](https://github.com/susumutomita/bioinformatics-note/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions. Since none of the steps in the workflow require write access to repository contents, issues, or pull requests, the minimal required permission is `contents: read`. This block can be added at the root level (before `jobs:`) to apply to all jobs in the workflow. No additional imports or definitions are needed; simply insert the following block after the workflow name and before the `on:` block:

```yaml
permissions:
  contents: read
```

This change ensures that the workflow adheres to the principle of least privilege and prevents accidental elevation of permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
